### PR TITLE
feat: formatPhoneNumber util function

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive collection of TypeScript utility functions for modern web develo
 
 ## Features
 
-- 🛠️ **Comprehensive**: String, object, cookie, number, validation, and common utilities
+- 🛠️ **Comprehensive**: String, object, cookie, number, validation, format, and common utilities
 - 📦 **Tree-shakable**: Import only what you need
 - 🔒 **Type-safe**: Full TypeScript support with type definitions
 - ⚡ **Lightweight**: Minimal dependencies and optimized for performance
@@ -30,6 +30,7 @@ import {
   numberUtil,
   validationUtil,
   commonUtil,
+  formatUtil,
 } from "kr-corekit";
 
 // String utilities
@@ -69,6 +70,8 @@ await commonUtil.sleep(1000); // Pauses execution for 1 second
 // Cookie utilities
 cookieUtil.setCookie("theme", "dark");
 const theme = cookieUtil.getCookie("theme");
+// Format utilities
+const formattedPhone = formatUtil.formatPhoneNumber("01012345678"); // "010-1234-5678"
 ```
 
 ## API Reference
@@ -89,6 +92,10 @@ const theme = cookieUtil.getCookie("theme");
 - `sum(...numbers: number[]): number` - Calculates sum of numbers
 - `subtract(...numbers: number[]): number` - Calculates subtraction of numbers
 - `multiply(...numbers: number[]): number` - Calculates multiplication of numbers
+
+### FormatUtil
+
+- `formatPhoneNumber(phone: string): string` - Formats a phone number string to a standard format (e.g., "010-1234-5678")
 
 ### ValidationUtil
 

--- a/package/formatUtil/formatPhoneNumber/index.test.ts
+++ b/package/formatUtil/formatPhoneNumber/index.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+import { formatPhoneNumber } from "."; // 실제 함수 경로에 맞게 수정해주세요.
+
+describe("formatPhoneNumber", () => {
+  describe("휴대폰 번호", () => {
+    test("11자리 휴대폰 번호에 하이픈을 올바르게 추가한다 (010)", () => {
+      expect(formatPhoneNumber("01012345678")).toBe("010-1234-5678");
+    });
+
+    test("11자리 휴대폰 번호에 하이픈을 올바르게 추가한다 (011)", () => {
+      expect(formatPhoneNumber("01198765432")).toBe("011-9876-5432");
+    });
+
+    test("중간에 공백이나 하이픈이 있어도 숫자를 제외하고 올바르게 처리한다", () => {
+      expect(formatPhoneNumber("010-1234 5678")).toBe("010-1234-5678");
+    });
+  });
+
+  describe("지역번호", () => {
+    test("서울 지역번호(02) 9자리에 하이픈을 올바르게 추가한다", () => {
+      expect(formatPhoneNumber("021234567")).toBe("02-123-4567");
+    });
+
+    test("서울 지역번호(02) 10자리에 하이픈을 올바르게 추가한다", () => {
+      expect(formatPhoneNumber("0212345678")).toBe("02-1234-5678");
+    });
+
+    test("서울 외 지역번호(031) 10자리에 하이픈을 올바르게 추가한다", () => {
+      expect(formatPhoneNumber("0311234567")).toBe("031-123-4567");
+    });
+
+    test("서울 외 지역번호(054) 10자리에 하이픈을 올바르게 추가한다", () => {
+      expect(formatPhoneNumber("0541234567")).toBe("054-123-4567");
+    });
+  });
+
+  describe("대표번호", () => {
+    test("8자리 대표번호(1588)에 하이픈을 올바르게 추가한다", () => {
+      expect(formatPhoneNumber("15881234")).toBe("1588-1234");
+    });
+
+    test("8자리 대표번호(1670)에 하이픈을 올바르게 추가한다", () => {
+      expect(formatPhoneNumber("16709876")).toBe("1670-9876");
+    });
+  });
+
+  describe("예외 케이스", () => {
+    test("빈 문자열을 입력하면 빈 문자열을 반환한다", () => {
+      expect(formatPhoneNumber("")).toBe("");
+    });
+
+    test("null 또는 undefined를 입력하면 빈 문자열을 반환한다", () => {
+      // @ts-ignore
+      expect(formatPhoneNumber(null)).toBe("");
+      // @ts-ignore
+      expect(formatPhoneNumber(undefined)).toBe("");
+    });
+
+    test("숫자가 아닌 문자가 포함된 경우, 해당 문자를 제거하고 포맷팅한다", () => {
+      expect(formatPhoneNumber("010-abcd-1234-efg-5678")).toBe("010-1234-5678");
+    });
+
+    test("어떤 형식에도 맞지 않는 짧은 길이라면 숫자만 반환한다", () => {
+      expect(formatPhoneNumber("12345")).toBe("12345");
+    });
+
+    test("어떤 형식에도 맞지 않는 긴 길이라면 숫자만 반환한다", () => {
+      expect(formatPhoneNumber("0101234567890")).toBe("0101234567890");
+    });
+  });
+});

--- a/package/formatUtil/formatPhoneNumber/index.test.ts
+++ b/package/formatUtil/formatPhoneNumber/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { formatPhoneNumber } from "."; // 실제 함수 경로에 맞게 수정해주세요.
+import formatPhoneNumber from ".";
 
 describe("formatPhoneNumber", () => {
   describe("휴대폰 번호", () => {

--- a/package/formatUtil/formatPhoneNumber/index.ts
+++ b/package/formatUtil/formatPhoneNumber/index.ts
@@ -34,22 +34,18 @@ const formatRules = [
   },
 ];
 
-export const formatPhoneNumber = (phoneNumber: string): string => {
-  if (!phoneNumber) {
-    return "";
-  }
+export default function formatPhoneNumber(phoneNumber: string): string {
+  if (!phoneNumber) return "";
 
   const digitsOnly = phoneNumber.replace(/\D/g, "");
 
-  for (const rule of formatRules) {
-    if (rule.prefix && !digitsOnly.startsWith(rule.prefix)) {
-      continue;
-    }
+  const matched = formatRules.find(
+    (rule) =>
+      (!rule.prefix || digitsOnly.startsWith(rule.prefix)) &&
+      digitsOnly.length === rule.length
+  );
 
-    if (digitsOnly.length === rule.length) {
-      return digitsOnly.replace(rule.format, rule.replacement);
-    }
-  }
-
-  return digitsOnly;
-};
+  return matched
+    ? digitsOnly.replace(matched.format, matched.replacement)
+    : digitsOnly;
+}

--- a/package/formatUtil/formatPhoneNumber/index.ts
+++ b/package/formatUtil/formatPhoneNumber/index.ts
@@ -1,0 +1,55 @@
+// 전화번호 형식 규칙을 데이터로 정의합니다.
+const formatRules = [
+  // 서울 지역번호 (02) - 9자리
+  {
+    prefix: "02",
+    length: 9,
+    format: /(\d{2})(\d{3})(\d{4})/,
+    replacement: "$1-$2-$3",
+  },
+  // 서울 지역번호 (02) - 10자리
+  {
+    prefix: "02",
+    length: 10,
+    format: /(\d{2})(\d{4})(\d{4})/,
+    replacement: "$1-$2-$3",
+  },
+  // 8자리 대표번호 (1588, 1670 등)
+  {
+    length: 8,
+    format: /(\d{4})(\d{4})/,
+    replacement: "$1-$2",
+  },
+  // 일반 지역번호 (031, 054 등)
+  {
+    length: 10,
+    format: /(\d{3})(\d{3})(\d{4})/,
+    replacement: "$1-$2-$3",
+  },
+  // 휴대폰 번호
+  {
+    length: 11,
+    format: /(\d{3})(\d{4})(\d{4})/,
+    replacement: "$1-$2-$3",
+  },
+];
+
+export const formatPhoneNumber = (phoneNumber: string): string => {
+  if (!phoneNumber) {
+    return "";
+  }
+
+  const digitsOnly = phoneNumber.replace(/\D/g, "");
+
+  for (const rule of formatRules) {
+    if (rule.prefix && !digitsOnly.startsWith(rule.prefix)) {
+      continue;
+    }
+
+    if (digitsOnly.length === rule.length) {
+      return digitsOnly.replace(rule.format, rule.replacement);
+    }
+  }
+
+  return digitsOnly;
+};

--- a/package/formatUtil/index.ts
+++ b/package/formatUtil/index.ts
@@ -1,0 +1,1 @@
+export { default as formatPhoneNumber } from "./formatPhoneNumber";

--- a/vitest-report.xml
+++ b/vitest-report.xml
@@ -1,205 +1,33 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<testsuites name="vitest tests" tests="85" failures="0" errors="0" time="0.030314623">
-    <testsuite name="package/commonUtil/isEmpty/index.test.ts" timestamp="2025-09-06T13:23:12.333Z" hostname="users-MacBook-Pro.local" tests="16" failures="0" errors="0" skipped="0" time="0.002486">
-        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 비어있지 않은 값에 대해 false를 반환해야 함 &gt; 비어있지 않은 문자열에 대해 false를 반환한다" time="0.000741583">
+<testsuites name="vitest tests" tests="14" failures="0" errors="0" time="0.002762667">
+    <testsuite name="package/formatUtil/formatPhoneNumber/index.test.ts" timestamp="2025-09-09T06:07:30.770Z" hostname="users-MacBook-Pro.local" tests="14" failures="0" errors="0" skipped="0" time="0.002762667">
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 휴대폰 번호 &gt; 11자리 휴대폰 번호에 하이픈을 올바르게 추가한다 (010)" time="0.000906209">
         </testcase>
-        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 비어있지 않은 값에 대해 false를 반환해야 함 &gt; 0이 아닌 숫자에 대해 false를 반환한다" time="0.00014525">
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 휴대폰 번호 &gt; 11자리 휴대폰 번호에 하이픈을 올바르게 추가한다 (011)" time="0.00012675">
         </testcase>
-        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 비어있지 않은 값에 대해 false를 반환해야 함 &gt; 비어있지 않은 배열에 대해 false를 반환한다" time="0.000116625">
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 휴대폰 번호 &gt; 중간에 공백이나 하이픈이 있어도 숫자를 제외하고 올바르게 처리한다" time="0.000072291">
         </testcase>
-        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 비어있지 않은 값에 대해 false를 반환해야 함 &gt; 0에 대해 false를 반환한다" time="0.000052292">
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 지역번호 &gt; 서울 지역번호(02) 9자리에 하이픈을 올바르게 추가한다" time="0.000138458">
         </testcase>
-        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 비어있지 않은 값에 대해 false를 반환해야 함 &gt; 비어있지 않은 객체에 대해 false를 반환한다" time="0.000102959">
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 지역번호 &gt; 서울 지역번호(02) 10자리에 하이픈을 올바르게 추가한다" time="0.000113125">
         </testcase>
-        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 비어있지 않은 값에 대해 false를 반환해야 함 &gt; 불린 값에 대해 false를 반환한다" time="0.000065167">
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 지역번호 &gt; 서울 외 지역번호(031) 10자리에 하이픈을 올바르게 추가한다" time="0.000140791">
         </testcase>
-        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 빈 값에 대해 true를 반환해야 함 &gt; 빈 문자열에 대해 true를 반환한다" time="0.000045625">
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 지역번호 &gt; 서울 외 지역번호(054) 10자리에 하이픈을 올바르게 추가한다" time="0.000074291">
         </testcase>
-        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 빈 값에 대해 true를 반환해야 함 &gt; 빈 배열에 대해 true를 반환한다" time="0.000039667">
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 대표번호 &gt; 8자리 대표번호(1588)에 하이픈을 올바르게 추가한다" time="0.000053708">
         </testcase>
-        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 빈 값에 대해 true를 반환해야 함 &gt; 빈 객체에 대해 true를 반환한다" time="0.00006">
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 대표번호 &gt; 8자리 대표번호(1670)에 하이픈을 올바르게 추가한다" time="0.000071584">
         </testcase>
-        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 빈 값에 대해 true를 반환해야 함 &gt; null과 undefined에 대해 true를 반환한다" time="0.000084792">
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 예외 케이스 &gt; 빈 문자열을 입력하면 빈 문자열을 반환한다" time="0.000062375">
         </testcase>
-        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 엣지 케이스 &gt; NaN을 처리한다" time="0.000062334">
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 예외 케이스 &gt; null 또는 undefined를 입력하면 빈 문자열을 반환한다" time="0.000056708">
         </testcase>
-        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 엣지 케이스 &gt; Date 객체를 처리한다" time="0.00006325">
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 예외 케이스 &gt; 숫자가 아닌 문자가 포함된 경우, 해당 문자를 제거하고 포맷팅한다" time="0.000037042">
         </testcase>
-        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 엣지 케이스 &gt; Set과 Map을 처리한다" time="0.000086166">
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 예외 케이스 &gt; 어떤 형식에도 맞지 않는 짧은 길이라면 숫자만 반환한다" time="0.000035">
         </testcase>
-        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 엣지 케이스 &gt; 함수를 처리한다" time="0.000045333">
-        </testcase>
-        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 엣지 케이스 &gt; 심볼을 처리한다" time="0.000033209">
-        </testcase>
-        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 엣지 케이스 &gt; 빈 심볼의 경우 true를 반환한다" time="0.00003075">
-        </testcase>
-    </testsuite>
-    <testsuite name="package/commonUtil/isNull/index.test.ts" timestamp="2025-09-06T13:23:12.334Z" hostname="users-MacBook-Pro.local" tests="5" failures="0" errors="0" skipped="0" time="0.001747916">
-        <testcase classname="package/commonUtil/isNull/index.test.ts" name="isNull 유틸 함수 테스트 &gt; null이 들어오는 경우 true를 반환한다." time="0.000664416">
-        </testcase>
-        <testcase classname="package/commonUtil/isNull/index.test.ts" name="isNull 유틸 함수 테스트 &gt; undefined이 들어오는 경우 false를 반환한다." time="0.000077542">
-        </testcase>
-        <testcase classname="package/commonUtil/isNull/index.test.ts" name="isNull 유틸 함수 테스트 &gt; 빈 문자열이 들어오는 경우 false를 반환한다." time="0.000064167">
-        </testcase>
-        <testcase classname="package/commonUtil/isNull/index.test.ts" name="isNull 유틸 함수 테스트 &gt; 공백 문자열이 들어오는 경우 false를 반환한다." time="0.000058958">
-        </testcase>
-        <testcase classname="package/commonUtil/isNull/index.test.ts" name="isNull 유틸 함수 테스트 &gt; 0이 들어오는 경우 false를 반환한다." time="0.00011525">
-        </testcase>
-    </testsuite>
-    <testsuite name="package/commonUtil/sleep/index.test.ts" timestamp="2025-09-06T13:23:12.335Z" hostname="users-MacBook-Pro.local" tests="4" failures="0" errors="0" skipped="0" time="0.00439025">
-        <testcase classname="package/commonUtil/sleep/index.test.ts" name="sleep &gt; 지정된 시간(ms) 이후에 resolve 되어야 한다" time="0.002168042">
-        </testcase>
-        <testcase classname="package/commonUtil/sleep/index.test.ts" name="sleep &gt; 지정된 시간 이전에는 resolve 되면 안 된다" time="0.000912042">
-        </testcase>
-        <testcase classname="package/commonUtil/sleep/index.test.ts" name="sleep &gt; ms가 0일 때 다음 틱(tick)에 resolve 되어야 한다" time="0.000417542">
-        </testcase>
-        <testcase classname="package/commonUtil/sleep/index.test.ts" name="sleep &gt; 음수 값은 0처럼 처리되어야 한다" time="0.0002805">
-        </testcase>
-    </testsuite>
-    <testsuite name="package/numberUtil/multiply/index.test.ts" timestamp="2025-09-06T13:23:12.335Z" hostname="users-MacBook-Pro.local" tests="9" failures="0" errors="0" skipped="0" time="0.002049917">
-        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 기본 케이스 &gt; 두 양수를 올바르게 곱한다" time="0.000701209">
-        </testcase>
-        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 기본 케이스 &gt; 여러 숫자를 올바르게 곱한다" time="0.000135625">
-        </testcase>
-        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 기본 케이스 &gt; 인수 중 0이 포함되면 0을 반환한다" time="0.00005725">
-        </testcase>
-        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 기본 케이스 &gt; 음수를 올바르게 처리한다" time="0.000080667">
-        </testcase>
-        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 기본 케이스 &gt; 부동소수점을 올바르게 처리한다" time="0.000050041">
-        </testcase>
-        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 엣지 케이스 &gt; 인수가 없을 때 1을 반환한다" time="0.0000595">
-        </testcase>
-        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 엣지 케이스 &gt; 인수가 하나일 때 해당 숫자 자신을 반환한다" time="0.000071792">
-        </testcase>
-        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 엣지 케이스 &gt; 인수 중 NaN이 포함되면 NaN을 반환한다" time="0.000091375">
-        </testcase>
-        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 엣지 케이스 &gt; Infinity(무한대)를 올바르게 처리한다" time="0.00007725">
-        </testcase>
-    </testsuite>
-    <testsuite name="package/numberUtil/subtract/index.test.ts" timestamp="2025-09-06T13:23:12.336Z" hostname="users-MacBook-Pro.local" tests="8" failures="0" errors="0" skipped="0" time="0.001920375">
-        <testcase classname="package/numberUtil/subtract/index.test.ts" name="subtract &gt; 기본 케이스 &gt; 두 양수를 올바르게 뺀다" time="0.000695583">
-        </testcase>
-        <testcase classname="package/numberUtil/subtract/index.test.ts" name="subtract &gt; 기본 케이스 &gt; 여러 숫자를 순서대로 뺀다" time="0.000082084">
-        </testcase>
-        <testcase classname="package/numberUtil/subtract/index.test.ts" name="subtract &gt; 기본 케이스 &gt; 음수를 포함한 뺄셈을 올바르게 처리한다" time="0.000078042">
-        </testcase>
-        <testcase classname="package/numberUtil/subtract/index.test.ts" name="subtract &gt; 예외 케이스 &gt; 인수가 없을 때 0을 반환한다" time="0.000063625">
-        </testcase>
-        <testcase classname="package/numberUtil/subtract/index.test.ts" name="subtract &gt; 예외 케이스 &gt; 인수가 하나일 때 해당 숫자 자신을 반환한다" time="0.00006825">
-        </testcase>
-        <testcase classname="package/numberUtil/subtract/index.test.ts" name="subtract &gt; 예외 케이스 &gt; 0을 포함한 뺄셈을 올바르게 처리한다" time="0.00007075">
-        </testcase>
-        <testcase classname="package/numberUtil/subtract/index.test.ts" name="subtract &gt; 예외 케이스 &gt; 부동소수점을 올바르게 처리한다" time="0.000083167">
-        </testcase>
-        <testcase classname="package/numberUtil/subtract/index.test.ts" name="subtract &gt; 예외 케이스 &gt; 인수 중 NaN이 포함되면 NaN을 반환한다" time="0.000059334">
-        </testcase>
-    </testsuite>
-    <testsuite name="package/numberUtil/sum/index.test.ts" timestamp="2025-09-06T13:23:12.337Z" hostname="users-MacBook-Pro.local" tests="7" failures="0" errors="0" skipped="0" time="0.001821041">
-        <testcase classname="package/numberUtil/sum/index.test.ts" name="sum &gt; 기본 케이스 &gt; 1 + 2 + 3은 6이다." time="0.000683042">
-        </testcase>
-        <testcase classname="package/numberUtil/sum/index.test.ts" name="sum &gt; 기본 케이스 &gt; 5 + 10 + 15는 30이다." time="0.000081792">
-        </testcase>
-        <testcase classname="package/numberUtil/sum/index.test.ts" name="sum &gt; 예외 케이스 &gt; 인수가 없을 때 0을 반환한다" time="0.000069792">
-        </testcase>
-        <testcase classname="package/numberUtil/sum/index.test.ts" name="sum &gt; 예외 케이스 &gt; 인수가 하나일 때 해당 숫자 자신을 반환한다" time="0.0000835">
-        </testcase>
-        <testcase classname="package/numberUtil/sum/index.test.ts" name="sum &gt; 예외 케이스 &gt; 음수를 포함한 덧셈을 올바르게 처리한다" time="0.000066584">
-        </testcase>
-        <testcase classname="package/numberUtil/sum/index.test.ts" name="sum &gt; 예외 케이스 &gt; 부동소수점을 올바르게 처리한다" time="0.000088875">
-        </testcase>
-        <testcase classname="package/numberUtil/sum/index.test.ts" name="sum &gt; 예외 케이스 &gt; 인수 중 NaN이 포함되면 NaN을 반환한다" time="0.000060542">
-        </testcase>
-    </testsuite>
-    <testsuite name="package/objectUtil/clearNullProperties/index.test.ts" timestamp="2025-09-06T13:23:12.337Z" hostname="users-MacBook-Pro.local" tests="1" failures="0" errors="0" skipped="0" time="0.001461208">
-        <testcase classname="package/objectUtil/clearNullProperties/index.test.ts" name="만약 Null이 객체에 존재한다면, Null이 없는 객체가 반환된다." time="0.000945208">
-        </testcase>
-    </testsuite>
-    <testsuite name="package/objectUtil/removeKey/index.test.ts" timestamp="2025-09-06T13:23:12.337Z" hostname="users-MacBook-Pro.local" tests="3" failures="0" errors="0" skipped="0" time="0.001809667">
-        <testcase classname="package/objectUtil/removeKey/index.test.ts" name="removeKey 유틸 함수 테스트 &gt; 객체와 키를 입력했을 때, 정상적으로 객체에서 속성이 제거되어야한다." time="0.000984125">
-        </testcase>
-        <testcase classname="package/objectUtil/removeKey/index.test.ts" name="removeKey 유틸 함수 테스트 &gt; 객체와 키를 입력했을 때, 제거할 키가 객체에 없으면 원본 객체가 반환되어야한다." time="0.000120375">
-        </testcase>
-        <testcase classname="package/objectUtil/removeKey/index.test.ts" name="removeKey 유틸 함수 테스트 &gt; 빈 객체와 키를 입력했을 때, 빈 객체가 반환되어야한다." time="0.000079667">
-        </testcase>
-    </testsuite>
-    <testsuite name="package/objectUtil/deepFreeze/index.test.ts" timestamp="2025-09-06T13:23:12.337Z" hostname="users-MacBook-Pro.local" tests="1" failures="0" errors="0" skipped="0" time="0.00127525">
-        <testcase classname="package/objectUtil/deepFreeze/index.test.ts" name="객체의 불변성이 유지된다." time="0.000749042">
-        </testcase>
-    </testsuite>
-    <testsuite name="package/stringUtil/unescapeHtml/index.test.ts" timestamp="2025-09-06T13:23:12.337Z" hostname="users-MacBook-Pro.local" tests="1" failures="0" errors="0" skipped="0" time="0.001148208">
-        <testcase classname="package/stringUtil/unescapeHtml/index.test.ts" name="HTML 특수 문자를 언이스케이프한다." time="0.000675292">
-        </testcase>
-    </testsuite>
-    <testsuite name="package/stringUtil/escapeHtml/index.test.ts" timestamp="2025-09-06T13:23:12.338Z" hostname="users-MacBook-Pro.local" tests="1" failures="0" errors="0" skipped="0" time="0.001262458">
-        <testcase classname="package/stringUtil/escapeHtml/index.test.ts" name="HTML 특수 문자를 이스케이프한다." time="0.000790042">
-        </testcase>
-    </testsuite>
-    <testsuite name="package/validationUtil/checkBase64/index.test.ts" timestamp="2025-09-06T13:23:12.338Z" hostname="users-MacBook-Pro.local" tests="3" failures="0" errors="0" skipped="0" time="0.001817958">
-        <testcase classname="package/validationUtil/checkBase64/index.test.ts" name="checkBase64 유틸 함수 테스트 &gt; 유효한 base64 문자열에 대해 true를 반환해야 합니다." time="0.000973625">
-        </testcase>
-        <testcase classname="package/validationUtil/checkBase64/index.test.ts" name="checkBase64 유틸 함수 테스트 &gt; 유효하지 않은 base64 문자열에 대해 false를 반환해야 합니다." time="0.000098792">
-        </testcase>
-        <testcase classname="package/validationUtil/checkBase64/index.test.ts" name="checkBase64 유틸 함수 테스트 &gt; 만약 빈 문자열로 함수를 호출할 경우 false를 반환해야 합니다." time="0.000082958">
-        </testcase>
-    </testsuite>
-    <testsuite name="package/validationUtil/checkDomain/index.test.ts" timestamp="2025-09-06T13:23:12.338Z" hostname="users-MacBook-Pro.local" tests="2" failures="0" errors="0" skipped="0" time="0.001932">
-        <testcase classname="package/validationUtil/checkDomain/index.test.ts" name="checkDomain 유틸 함수 테스트 &gt; 유효한 도메인이 들어오는 경우 true를 반환한다." time="0.000887667">
-        </testcase>
-        <testcase classname="package/validationUtil/checkDomain/index.test.ts" name="checkDomain 유틸 함수 테스트 &gt; 유효하지 않은 도메인이 들어오는 경우 false를 반환한다." time="0.000116792">
-        </testcase>
-    </testsuite>
-    <testsuite name="package/validationUtil/checkEmail/index.test.ts" timestamp="2025-09-06T13:23:12.338Z" hostname="users-MacBook-Pro.local" tests="2" failures="0" errors="0" skipped="0" time="0.001327583">
-        <testcase classname="package/validationUtil/checkEmail/index.test.ts" name="올바른 이메일인 경우 true 값을 리턴합니다." time="0.000703916">
-        </testcase>
-        <testcase classname="package/validationUtil/checkEmail/index.test.ts" name="올바르지 않은 이메일인 경우 false 값을 리턴합니다." time="0.000112">
-        </testcase>
-    </testsuite>
-    <testsuite name="package/validationUtil/checkHttpUrl/index.test.ts" timestamp="2025-09-06T13:23:12.338Z" hostname="users-MacBook-Pro.local" tests="16" failures="0" errors="0" skipped="0" time="0.002119125">
-        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효한 HTTP/HTTPS URL 문자열이 주어졌을 때 &gt; &apos;http://example.com&apos;에 대해 true를 반환한다" time="0.0006975">
-        </testcase>
-        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효한 HTTP/HTTPS URL 문자열이 주어졌을 때 &gt; &apos;https://example.com&apos;에 대해 true를 반환한다" time="0.000072875">
-        </testcase>
-        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효한 HTTP/HTTPS URL 문자열이 주어졌을 때 &gt; &apos;https://www.example.com&apos;에 대해 true를 반환한다" time="0.000049208">
-        </testcase>
-        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효한 HTTP/HTTPS URL 문자열이 주어졌을 때 &gt; &apos;http://example.com/path/to/resource&apos;에 대해 true를 반환한다" time="0.00005225">
-        </testcase>
-        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효한 HTTP/HTTPS URL 문자열이 주어졌을 때 &gt; &apos;https://example.com?query=123&amp;key=value&apos;에 대해 true를 반환한다" time="0.000046791">
-        </testcase>
-        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효한 HTTP/HTTPS URL 문자열이 주어졌을 때 &gt; &apos;http://localhost:3000&apos;에 대해 true를 반환한다" time="0.00005475">
-        </testcase>
-        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효한 HTTP/HTTPS URL 문자열이 주어졌을 때 &gt; &apos;https://sub.domain.co.uk/page#section&apos;에 대해 true를 반환한다" time="0.000037917">
-        </testcase>
-        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;www.example.com&apos;에 대해 false를 반환한다" time="0.000068458">
-        </testcase>
-        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;example.com&apos;에 대해 false를 반환한다" time="0.0000565">
-        </testcase>
-        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;/relative/path&apos;에 대해 false를 반환한다" time="0.000066875">
-        </testcase>
-        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;ftp://example.com&apos;에 대해 false를 반환한다" time="0.000038792">
-        </testcase>
-        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;mailto:test@example.com&apos;에 대해 false를 반환한다" time="0.000029333">
-        </testcase>
-        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;http:// example.com&apos;에 대해 false를 반환한다" time="0.00003475">
-        </testcase>
-        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;https://&apos;에 대해 false를 반환한다" time="0.0000355">
-        </testcase>
-        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;just a random string&apos;에 대해 false를 반환한다" time="0.000031625">
-        </testcase>
-        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;&apos;에 대해 false를 반환한다" time="0.000033292">
-        </testcase>
-    </testsuite>
-    <testsuite name="package/validationUtil/checkPassword/index.test.ts" timestamp="2025-09-06T13:23:12.340Z" hostname="users-MacBook-Pro.local" tests="6" failures="0" errors="0" skipped="0" time="0.001745667">
-        <testcase classname="package/validationUtil/checkPassword/index.test.ts" name="checkPassword 유틸 함수 테스트 &gt; 유효한 비밀번호에 대해 true를 반환해야 합니다. &gt; 기본 상태는 아무 옵션도 설정되어있지 않기 때문에 true를 반환해야 합니다." time="0.000688208">
-        </testcase>
-        <testcase classname="package/validationUtil/checkPassword/index.test.ts" name="checkPassword 유틸 함수 테스트 &gt; 유효한 비밀번호에 대해 true를 반환해야 합니다. &gt; 특수 문자가 필요한 경우 true를 반환해야 합니다." time="0.00009825">
-        </testcase>
-        <testcase classname="package/validationUtil/checkPassword/index.test.ts" name="checkPassword 유틸 함수 테스트 &gt; 유효한 비밀번호에 대해 true를 반환해야 합니다. &gt; 대문자가 필요한 경우 true를 반환해야 합니다." time="0.000070167">
-        </testcase>
-        <testcase classname="package/validationUtil/checkPassword/index.test.ts" name="checkPassword 유틸 함수 테스트 &gt; 유효한 비밀번호에 대해 true를 반환해야 합니다. &gt; 최소 3자, 최대 5자의 길이를 가져야 하는 경우 true를 반환해야 합니다." time="0.000061375">
-        </testcase>
-        <testcase classname="package/validationUtil/checkPassword/index.test.ts" name="checkPassword 유틸 함수 테스트 &gt; 유효하지 않은 비밀번호에 대해 false를 반환해야 합니다. &gt; 길이가 유효하지 않은 경우 false를 반환해야 합니다." time="0.000061709">
-        </testcase>
-        <testcase classname="package/validationUtil/checkPassword/index.test.ts" name="checkPassword 유틸 함수 테스트 &gt; 유효하지 않은 비밀번호에 대해 false를 반환해야 합니다. &gt; 특수 문자가 없는 경우 false를 반환해야 합니다." time="0.000082333">
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 예외 케이스 &gt; 어떤 형식에도 맞지 않는 긴 길이라면 숫자만 반환한다" time="0.00004375">
         </testcase>
     </testsuite>
 </testsuites>

--- a/vitest-report.xml
+++ b/vitest-report.xml
@@ -1,33 +1,235 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<testsuites name="vitest tests" tests="14" failures="0" errors="0" time="0.002762667">
-    <testsuite name="package/formatUtil/formatPhoneNumber/index.test.ts" timestamp="2025-09-09T06:07:30.770Z" hostname="users-MacBook-Pro.local" tests="14" failures="0" errors="0" skipped="0" time="0.002762667">
-        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 휴대폰 번호 &gt; 11자리 휴대폰 번호에 하이픈을 올바르게 추가한다 (010)" time="0.000906209">
+<testsuites name="vitest tests" tests="99" failures="0" errors="0" time="0.036835043">
+    <testsuite name="package/commonUtil/isEmpty/index.test.ts" timestamp="2025-09-10T08:15:15.160Z" hostname="users-MacBook-Pro.local" tests="16" failures="0" errors="0" skipped="0" time="0.003237375">
+        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 비어있지 않은 값에 대해 false를 반환해야 함 &gt; 비어있지 않은 문자열에 대해 false를 반환한다" time="0.000975">
         </testcase>
-        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 휴대폰 번호 &gt; 11자리 휴대폰 번호에 하이픈을 올바르게 추가한다 (011)" time="0.00012675">
+        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 비어있지 않은 값에 대해 false를 반환해야 함 &gt; 0이 아닌 숫자에 대해 false를 반환한다" time="0.000415042">
         </testcase>
-        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 휴대폰 번호 &gt; 중간에 공백이나 하이픈이 있어도 숫자를 제외하고 올바르게 처리한다" time="0.000072291">
+        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 비어있지 않은 값에 대해 false를 반환해야 함 &gt; 비어있지 않은 배열에 대해 false를 반환한다" time="0.000139333">
         </testcase>
-        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 지역번호 &gt; 서울 지역번호(02) 9자리에 하이픈을 올바르게 추가한다" time="0.000138458">
+        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 비어있지 않은 값에 대해 false를 반환해야 함 &gt; 0에 대해 false를 반환한다" time="0.000061791">
         </testcase>
-        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 지역번호 &gt; 서울 지역번호(02) 10자리에 하이픈을 올바르게 추가한다" time="0.000113125">
+        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 비어있지 않은 값에 대해 false를 반환해야 함 &gt; 비어있지 않은 객체에 대해 false를 반환한다" time="0.00012575">
         </testcase>
-        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 지역번호 &gt; 서울 외 지역번호(031) 10자리에 하이픈을 올바르게 추가한다" time="0.000140791">
+        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 비어있지 않은 값에 대해 false를 반환해야 함 &gt; 불린 값에 대해 false를 반환한다" time="0.000073667">
         </testcase>
-        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 지역번호 &gt; 서울 외 지역번호(054) 10자리에 하이픈을 올바르게 추가한다" time="0.000074291">
+        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 빈 값에 대해 true를 반환해야 함 &gt; 빈 문자열에 대해 true를 반환한다" time="0.000054583">
         </testcase>
-        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 대표번호 &gt; 8자리 대표번호(1588)에 하이픈을 올바르게 추가한다" time="0.000053708">
+        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 빈 값에 대해 true를 반환해야 함 &gt; 빈 배열에 대해 true를 반환한다" time="0.000043417">
         </testcase>
-        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 대표번호 &gt; 8자리 대표번호(1670)에 하이픈을 올바르게 추가한다" time="0.000071584">
+        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 빈 값에 대해 true를 반환해야 함 &gt; 빈 객체에 대해 true를 반환한다" time="0.00006925">
         </testcase>
-        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 예외 케이스 &gt; 빈 문자열을 입력하면 빈 문자열을 반환한다" time="0.000062375">
+        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 빈 값에 대해 true를 반환해야 함 &gt; null과 undefined에 대해 true를 반환한다" time="0.000082208">
         </testcase>
-        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 예외 케이스 &gt; null 또는 undefined를 입력하면 빈 문자열을 반환한다" time="0.000056708">
+        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 엣지 케이스 &gt; NaN을 처리한다" time="0.000049667">
         </testcase>
-        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 예외 케이스 &gt; 숫자가 아닌 문자가 포함된 경우, 해당 문자를 제거하고 포맷팅한다" time="0.000037042">
+        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 엣지 케이스 &gt; Date 객체를 처리한다" time="0.000061667">
         </testcase>
-        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 예외 케이스 &gt; 어떤 형식에도 맞지 않는 짧은 길이라면 숫자만 반환한다" time="0.000035">
+        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 엣지 케이스 &gt; Set과 Map을 처리한다" time="0.000081917">
         </testcase>
-        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 예외 케이스 &gt; 어떤 형식에도 맞지 않는 긴 길이라면 숫자만 반환한다" time="0.00004375">
+        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 엣지 케이스 &gt; 함수를 처리한다" time="0.000052125">
+        </testcase>
+        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 엣지 케이스 &gt; 심볼을 처리한다" time="0.000044417">
+        </testcase>
+        <testcase classname="package/commonUtil/isEmpty/index.test.ts" name="isEmpty 유틸 함수 테스트 &gt; 엣지 케이스 &gt; 빈 심볼의 경우 true를 반환한다" time="0.000040084">
+        </testcase>
+    </testsuite>
+    <testsuite name="package/commonUtil/sleep/index.test.ts" timestamp="2025-09-10T08:15:15.162Z" hostname="users-MacBook-Pro.local" tests="4" failures="0" errors="0" skipped="0" time="0.007134334">
+        <testcase classname="package/commonUtil/sleep/index.test.ts" name="sleep &gt; 지정된 시간(ms) 이후에 resolve 되어야 한다" time="0.00271875">
+        </testcase>
+        <testcase classname="package/commonUtil/sleep/index.test.ts" name="sleep &gt; 지정된 시간 이전에는 resolve 되면 안 된다" time="0.001454125">
+        </testcase>
+        <testcase classname="package/commonUtil/sleep/index.test.ts" name="sleep &gt; ms가 0일 때 다음 틱(tick)에 resolve 되어야 한다" time="0.000788584">
+        </testcase>
+        <testcase classname="package/commonUtil/sleep/index.test.ts" name="sleep &gt; 음수 값은 0처럼 처리되어야 한다" time="0.001498875">
+        </testcase>
+    </testsuite>
+    <testsuite name="package/commonUtil/isNull/index.test.ts" timestamp="2025-09-10T08:15:15.162Z" hostname="users-MacBook-Pro.local" tests="5" failures="0" errors="0" skipped="0" time="0.001557958">
+        <testcase classname="package/commonUtil/isNull/index.test.ts" name="isNull 유틸 함수 테스트 &gt; null이 들어오는 경우 true를 반환한다." time="0.000692875">
+        </testcase>
+        <testcase classname="package/commonUtil/isNull/index.test.ts" name="isNull 유틸 함수 테스트 &gt; undefined이 들어오는 경우 false를 반환한다." time="0.000081125">
+        </testcase>
+        <testcase classname="package/commonUtil/isNull/index.test.ts" name="isNull 유틸 함수 테스트 &gt; 빈 문자열이 들어오는 경우 false를 반환한다." time="0.000065042">
+        </testcase>
+        <testcase classname="package/commonUtil/isNull/index.test.ts" name="isNull 유틸 함수 테스트 &gt; 공백 문자열이 들어오는 경우 false를 반환한다." time="0.0000525">
+        </testcase>
+        <testcase classname="package/commonUtil/isNull/index.test.ts" name="isNull 유틸 함수 테스트 &gt; 0이 들어오는 경우 false를 반환한다." time="0.000056291">
+        </testcase>
+    </testsuite>
+    <testsuite name="package/formatUtil/formatPhoneNumber/index.test.ts" timestamp="2025-09-10T08:15:15.163Z" hostname="users-MacBook-Pro.local" tests="14" failures="0" errors="0" skipped="0" time="0.002413875">
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 휴대폰 번호 &gt; 11자리 휴대폰 번호에 하이픈을 올바르게 추가한다 (010)" time="0.000786542">
+        </testcase>
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 휴대폰 번호 &gt; 11자리 휴대폰 번호에 하이픈을 올바르게 추가한다 (011)" time="0.000115333">
+        </testcase>
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 휴대폰 번호 &gt; 중간에 공백이나 하이픈이 있어도 숫자를 제외하고 올바르게 처리한다" time="0.000067375">
+        </testcase>
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 지역번호 &gt; 서울 지역번호(02) 9자리에 하이픈을 올바르게 추가한다" time="0.00007825">
+        </testcase>
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 지역번호 &gt; 서울 지역번호(02) 10자리에 하이픈을 올바르게 추가한다" time="0.0000725">
+        </testcase>
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 지역번호 &gt; 서울 외 지역번호(031) 10자리에 하이픈을 올바르게 추가한다" time="0.000075167">
+        </testcase>
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 지역번호 &gt; 서울 외 지역번호(054) 10자리에 하이픈을 올바르게 추가한다" time="0.000072541">
+        </testcase>
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 대표번호 &gt; 8자리 대표번호(1588)에 하이픈을 올바르게 추가한다" time="0.000057708">
+        </testcase>
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 대표번호 &gt; 8자리 대표번호(1670)에 하이픈을 올바르게 추가한다" time="0.000080792">
+        </testcase>
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 예외 케이스 &gt; 빈 문자열을 입력하면 빈 문자열을 반환한다" time="0.000073583">
+        </testcase>
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 예외 케이스 &gt; null 또는 undefined를 입력하면 빈 문자열을 반환한다" time="0.000062167">
+        </testcase>
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 예외 케이스 &gt; 숫자가 아닌 문자가 포함된 경우, 해당 문자를 제거하고 포맷팅한다" time="0.00004425">
+        </testcase>
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 예외 케이스 &gt; 어떤 형식에도 맞지 않는 짧은 길이라면 숫자만 반환한다" time="0.000039209">
+        </testcase>
+        <testcase classname="package/formatUtil/formatPhoneNumber/index.test.ts" name="formatPhoneNumber &gt; 예외 케이스 &gt; 어떤 형식에도 맞지 않는 긴 길이라면 숫자만 반환한다" time="0.000035625">
+        </testcase>
+    </testsuite>
+    <testsuite name="package/numberUtil/multiply/index.test.ts" timestamp="2025-09-10T08:15:15.165Z" hostname="users-MacBook-Pro.local" tests="9" failures="0" errors="0" skipped="0" time="0.002202459">
+        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 기본 케이스 &gt; 두 양수를 올바르게 곱한다" time="0.000753">
+        </testcase>
+        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 기본 케이스 &gt; 여러 숫자를 올바르게 곱한다" time="0.000119709">
+        </testcase>
+        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 기본 케이스 &gt; 인수 중 0이 포함되면 0을 반환한다" time="0.000065917">
+        </testcase>
+        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 기본 케이스 &gt; 음수를 올바르게 처리한다" time="0.000083708">
+        </testcase>
+        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 기본 케이스 &gt; 부동소수점을 올바르게 처리한다" time="0.000056083">
+        </testcase>
+        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 엣지 케이스 &gt; 인수가 없을 때 1을 반환한다" time="0.00006825">
+        </testcase>
+        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 엣지 케이스 &gt; 인수가 하나일 때 해당 숫자 자신을 반환한다" time="0.000071917">
+        </testcase>
+        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 엣지 케이스 &gt; 인수 중 NaN이 포함되면 NaN을 반환한다" time="0.000181709">
+        </testcase>
+        <testcase classname="package/numberUtil/multiply/index.test.ts" name="multiply &gt; 엣지 케이스 &gt; Infinity(무한대)를 올바르게 처리한다" time="0.000117833">
+        </testcase>
+    </testsuite>
+    <testsuite name="package/numberUtil/subtract/index.test.ts" timestamp="2025-09-10T08:15:15.165Z" hostname="users-MacBook-Pro.local" tests="8" failures="0" errors="0" skipped="0" time="0.001794958">
+        <testcase classname="package/numberUtil/subtract/index.test.ts" name="subtract &gt; 기본 케이스 &gt; 두 양수를 올바르게 뺀다" time="0.000652166">
+        </testcase>
+        <testcase classname="package/numberUtil/subtract/index.test.ts" name="subtract &gt; 기본 케이스 &gt; 여러 숫자를 순서대로 뺀다" time="0.00008">
+        </testcase>
+        <testcase classname="package/numberUtil/subtract/index.test.ts" name="subtract &gt; 기본 케이스 &gt; 음수를 포함한 뺄셈을 올바르게 처리한다" time="0.000077417">
+        </testcase>
+        <testcase classname="package/numberUtil/subtract/index.test.ts" name="subtract &gt; 예외 케이스 &gt; 인수가 없을 때 0을 반환한다" time="0.000062792">
+        </testcase>
+        <testcase classname="package/numberUtil/subtract/index.test.ts" name="subtract &gt; 예외 케이스 &gt; 인수가 하나일 때 해당 숫자 자신을 반환한다" time="0.000066875">
+        </testcase>
+        <testcase classname="package/numberUtil/subtract/index.test.ts" name="subtract &gt; 예외 케이스 &gt; 0을 포함한 뺄셈을 올바르게 처리한다" time="0.000074542">
+        </testcase>
+        <testcase classname="package/numberUtil/subtract/index.test.ts" name="subtract &gt; 예외 케이스 &gt; 부동소수점을 올바르게 처리한다" time="0.000085625">
+        </testcase>
+        <testcase classname="package/numberUtil/subtract/index.test.ts" name="subtract &gt; 예외 케이스 &gt; 인수 중 NaN이 포함되면 NaN을 반환한다" time="0.000060041">
+        </testcase>
+    </testsuite>
+    <testsuite name="package/numberUtil/sum/index.test.ts" timestamp="2025-09-10T08:15:15.166Z" hostname="users-MacBook-Pro.local" tests="7" failures="0" errors="0" skipped="0" time="0.001756875">
+        <testcase classname="package/numberUtil/sum/index.test.ts" name="sum &gt; 기본 케이스 &gt; 1 + 2 + 3은 6이다." time="0.000676125">
+        </testcase>
+        <testcase classname="package/numberUtil/sum/index.test.ts" name="sum &gt; 기본 케이스 &gt; 5 + 10 + 15는 30이다." time="0.000080875">
+        </testcase>
+        <testcase classname="package/numberUtil/sum/index.test.ts" name="sum &gt; 예외 케이스 &gt; 인수가 없을 때 0을 반환한다" time="0.000067541">
+        </testcase>
+        <testcase classname="package/numberUtil/sum/index.test.ts" name="sum &gt; 예외 케이스 &gt; 인수가 하나일 때 해당 숫자 자신을 반환한다" time="0.000076417">
+        </testcase>
+        <testcase classname="package/numberUtil/sum/index.test.ts" name="sum &gt; 예외 케이스 &gt; 음수를 포함한 덧셈을 올바르게 처리한다" time="0.000065167">
+        </testcase>
+        <testcase classname="package/numberUtil/sum/index.test.ts" name="sum &gt; 예외 케이스 &gt; 부동소수점을 올바르게 처리한다" time="0.000090958">
+        </testcase>
+        <testcase classname="package/numberUtil/sum/index.test.ts" name="sum &gt; 예외 케이스 &gt; 인수 중 NaN이 포함되면 NaN을 반환한다" time="0.000057584">
+        </testcase>
+    </testsuite>
+    <testsuite name="package/objectUtil/clearNullProperties/index.test.ts" timestamp="2025-09-10T08:15:15.166Z" hostname="users-MacBook-Pro.local" tests="1" failures="0" errors="0" skipped="0" time="0.001475208">
+        <testcase classname="package/objectUtil/clearNullProperties/index.test.ts" name="만약 Null이 객체에 존재한다면, Null이 없는 객체가 반환된다." time="0.000936208">
+        </testcase>
+    </testsuite>
+    <testsuite name="package/objectUtil/deepFreeze/index.test.ts" timestamp="2025-09-10T08:15:15.167Z" hostname="users-MacBook-Pro.local" tests="1" failures="0" errors="0" skipped="0" time="0.001402458">
+        <testcase classname="package/objectUtil/deepFreeze/index.test.ts" name="객체의 불변성이 유지된다." time="0.000857083">
+        </testcase>
+    </testsuite>
+    <testsuite name="package/objectUtil/removeKey/index.test.ts" timestamp="2025-09-10T08:15:15.167Z" hostname="users-MacBook-Pro.local" tests="3" failures="0" errors="0" skipped="0" time="0.001705209">
+        <testcase classname="package/objectUtil/removeKey/index.test.ts" name="removeKey 유틸 함수 테스트 &gt; 객체와 키를 입력했을 때, 정상적으로 객체에서 속성이 제거되어야한다." time="0.000908292">
+        </testcase>
+        <testcase classname="package/objectUtil/removeKey/index.test.ts" name="removeKey 유틸 함수 테스트 &gt; 객체와 키를 입력했을 때, 제거할 키가 객체에 없으면 원본 객체가 반환되어야한다." time="0.000099042">
+        </testcase>
+        <testcase classname="package/objectUtil/removeKey/index.test.ts" name="removeKey 유틸 함수 테스트 &gt; 빈 객체와 키를 입력했을 때, 빈 객체가 반환되어야한다." time="0.000073">
+        </testcase>
+    </testsuite>
+    <testsuite name="package/stringUtil/escapeHtml/index.test.ts" timestamp="2025-09-10T08:15:15.167Z" hostname="users-MacBook-Pro.local" tests="1" failures="0" errors="0" skipped="0" time="0.001191375">
+        <testcase classname="package/stringUtil/escapeHtml/index.test.ts" name="HTML 특수 문자를 이스케이프한다." time="0.000675291">
+        </testcase>
+    </testsuite>
+    <testsuite name="package/stringUtil/unescapeHtml/index.test.ts" timestamp="2025-09-10T08:15:15.167Z" hostname="users-MacBook-Pro.local" tests="1" failures="0" errors="0" skipped="0" time="0.001348375">
+        <testcase classname="package/stringUtil/unescapeHtml/index.test.ts" name="HTML 특수 문자를 언이스케이프한다." time="0.000870875">
+        </testcase>
+    </testsuite>
+    <testsuite name="package/validationUtil/checkBase64/index.test.ts" timestamp="2025-09-10T08:15:15.167Z" hostname="users-MacBook-Pro.local" tests="3" failures="0" errors="0" skipped="0" time="0.001740667">
+        <testcase classname="package/validationUtil/checkBase64/index.test.ts" name="checkBase64 유틸 함수 테스트 &gt; 유효한 base64 문자열에 대해 true를 반환해야 합니다." time="0.000926833">
+        </testcase>
+        <testcase classname="package/validationUtil/checkBase64/index.test.ts" name="checkBase64 유틸 함수 테스트 &gt; 유효하지 않은 base64 문자열에 대해 false를 반환해야 합니다." time="0.000096417">
+        </testcase>
+        <testcase classname="package/validationUtil/checkBase64/index.test.ts" name="checkBase64 유틸 함수 테스트 &gt; 만약 빈 문자열로 함수를 호출할 경우 false를 반환해야 합니다." time="0.000088666">
+        </testcase>
+    </testsuite>
+    <testsuite name="package/validationUtil/checkDomain/index.test.ts" timestamp="2025-09-10T08:15:15.168Z" hostname="users-MacBook-Pro.local" tests="2" failures="0" errors="0" skipped="0" time="0.001652875">
+        <testcase classname="package/validationUtil/checkDomain/index.test.ts" name="checkDomain 유틸 함수 테스트 &gt; 유효한 도메인이 들어오는 경우 true를 반환한다." time="0.000853458">
+        </testcase>
+        <testcase classname="package/validationUtil/checkDomain/index.test.ts" name="checkDomain 유틸 함수 테스트 &gt; 유효하지 않은 도메인이 들어오는 경우 false를 반환한다." time="0.000137667">
+        </testcase>
+    </testsuite>
+    <testsuite name="package/validationUtil/checkEmail/index.test.ts" timestamp="2025-09-10T08:15:15.168Z" hostname="users-MacBook-Pro.local" tests="2" failures="0" errors="0" skipped="0" time="0.001390708">
+        <testcase classname="package/validationUtil/checkEmail/index.test.ts" name="올바른 이메일인 경우 true 값을 리턴합니다." time="0.000734958">
+        </testcase>
+        <testcase classname="package/validationUtil/checkEmail/index.test.ts" name="올바르지 않은 이메일인 경우 false 값을 리턴합니다." time="0.000114542">
+        </testcase>
+    </testsuite>
+    <testsuite name="package/validationUtil/checkHttpUrl/index.test.ts" timestamp="2025-09-10T08:15:15.168Z" hostname="users-MacBook-Pro.local" tests="16" failures="0" errors="0" skipped="0" time="0.0030795">
+        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효한 HTTP/HTTPS URL 문자열이 주어졌을 때 &gt; &apos;http://example.com&apos;에 대해 true를 반환한다" time="0.000725291">
+        </testcase>
+        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효한 HTTP/HTTPS URL 문자열이 주어졌을 때 &gt; &apos;https://example.com&apos;에 대해 true를 반환한다" time="0.000078125">
+        </testcase>
+        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효한 HTTP/HTTPS URL 문자열이 주어졌을 때 &gt; &apos;https://www.example.com&apos;에 대해 true를 반환한다" time="0.000054625">
+        </testcase>
+        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효한 HTTP/HTTPS URL 문자열이 주어졌을 때 &gt; &apos;http://example.com/path/to/resource&apos;에 대해 true를 반환한다" time="0.000054083">
+        </testcase>
+        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효한 HTTP/HTTPS URL 문자열이 주어졌을 때 &gt; &apos;https://example.com?query=123&amp;key=value&apos;에 대해 true를 반환한다" time="0.000051666">
+        </testcase>
+        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효한 HTTP/HTTPS URL 문자열이 주어졌을 때 &gt; &apos;http://localhost:3000&apos;에 대해 true를 반환한다" time="0.00005475">
+        </testcase>
+        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효한 HTTP/HTTPS URL 문자열이 주어졌을 때 &gt; &apos;https://sub.domain.co.uk/page#section&apos;에 대해 true를 반환한다" time="0.000040417">
+        </testcase>
+        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;www.example.com&apos;에 대해 false를 반환한다" time="0.000146958">
+        </testcase>
+        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;example.com&apos;에 대해 false를 반환한다" time="0.000071042">
+        </testcase>
+        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;/relative/path&apos;에 대해 false를 반환한다" time="0.000075375">
+        </testcase>
+        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;ftp://example.com&apos;에 대해 false를 반환한다" time="0.00004725">
+        </testcase>
+        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;mailto:test@example.com&apos;에 대해 false를 반환한다" time="0.000034791">
+        </testcase>
+        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;http:// example.com&apos;에 대해 false를 반환한다" time="0.000039542">
+        </testcase>
+        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;https://&apos;에 대해 false를 반환한다" time="0.000039208">
+        </testcase>
+        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;just a random string&apos;에 대해 false를 반환한다" time="0.00003625">
+        </testcase>
+        <testcase classname="package/validationUtil/checkHttpUrl/index.test.ts" name="URL 유효성 검사 &gt; 유효하지 않은 URL 문자열이 주어졌을 때 &gt; &apos;&apos;에 대해 false를 반환한다" time="0.000038167">
+        </testcase>
+    </testsuite>
+    <testsuite name="package/validationUtil/checkPassword/index.test.ts" timestamp="2025-09-10T08:15:15.170Z" hostname="users-MacBook-Pro.local" tests="6" failures="0" errors="0" skipped="0" time="0.001750834">
+        <testcase classname="package/validationUtil/checkPassword/index.test.ts" name="checkPassword 유틸 함수 테스트 &gt; 유효한 비밀번호에 대해 true를 반환해야 합니다. &gt; 기본 상태는 아무 옵션도 설정되어있지 않기 때문에 true를 반환해야 합니다." time="0.000696875">
+        </testcase>
+        <testcase classname="package/validationUtil/checkPassword/index.test.ts" name="checkPassword 유틸 함수 테스트 &gt; 유효한 비밀번호에 대해 true를 반환해야 합니다. &gt; 특수 문자가 필요한 경우 true를 반환해야 합니다." time="0.000097542">
+        </testcase>
+        <testcase classname="package/validationUtil/checkPassword/index.test.ts" name="checkPassword 유틸 함수 테스트 &gt; 유효한 비밀번호에 대해 true를 반환해야 합니다. &gt; 대문자가 필요한 경우 true를 반환해야 합니다." time="0.0000705">
+        </testcase>
+        <testcase classname="package/validationUtil/checkPassword/index.test.ts" name="checkPassword 유틸 함수 테스트 &gt; 유효한 비밀번호에 대해 true를 반환해야 합니다. &gt; 최소 3자, 최대 5자의 길이를 가져야 하는 경우 true를 반환해야 합니다." time="0.000065042">
+        </testcase>
+        <testcase classname="package/validationUtil/checkPassword/index.test.ts" name="checkPassword 유틸 함수 테스트 &gt; 유효하지 않은 비밀번호에 대해 false를 반환해야 합니다. &gt; 길이가 유효하지 않은 경우 false를 반환해야 합니다." time="0.000063792">
+        </testcase>
+        <testcase classname="package/validationUtil/checkPassword/index.test.ts" name="checkPassword 유틸 함수 테스트 &gt; 유효하지 않은 비밀번호에 대해 false를 반환해야 합니다. &gt; 특수 문자가 없는 경우 false를 반환해야 합니다." time="0.00008225">
         </testcase>
     </testsuite>
 </testsuites>


### PR DESCRIPTION
### Description

프론트엔드에서 흔히 사용되는 전화번호 자동 하이픈(-) 추가 기능을 구현한 `formatPhoneNumber` 유틸리티 함수를 추가합니다.

다양한 케이스에 대응할 수 있도록 함수를 구현하고, vitest를 이용한 테스트 코드를 작성하여 안정성을 높였습니다.

주요 변경 사항

- `formatPhoneNumber` 함수 신규 구현
- 휴대폰, 서울/기타 지역번호, 8자리 대표번호 등 한국의 주요 전화번호 형식을 자동으로 포맷팅합니다.

close #35 